### PR TITLE
Model Architecture Edit

### DIFF
--- a/model.py
+++ b/model.py
@@ -30,19 +30,24 @@ class ImgModel(nn.Module):
         self.merged_cnn = nn.Sequential(
             nn.Conv2d(2 * cnn_channels[1], cnn_channels[1], kernel_size=3, padding=1),
             nn.ReLU(),
-            nn.Upsample(scale_factor=2, mode='nearest'),
+            nn.Upsample(scale_factor=2, mode='bilinear', align_corners=True),
             nn.Conv2d(cnn_channels[1], cnn_channels[0], kernel_size=3, padding=1),
             nn.ReLU(),
-            nn.Upsample(scale_factor=2, mode='nearest')
+            nn.Upsample(scale_factor=2, mode='bilinear', align_corners=True)
         )
         self.output_layer = nn.Conv2d(cnn_channels[0], 3, kernel_size=3, padding=1)
         
+        self.dropout = nn.Dropout2d(p=0.5)
+
     def forward(self, color_input, depth_input):
         c_cnn = self.color_cnn(color_input)
         d_cnn = self.depth_cnn(depth_input)
+
+        c_cnn = self.dropout(c_cnn)
+        d_cnn = self.dropout(d_cnn)
+        
         merged = torch.cat([c_cnn, d_cnn], dim=1)
         merged = self.merged_cnn(merged)
         output = self.output_layer(merged)
 
         return output
-


### PR DESCRIPTION
This modification introduces dropout regularization to the model and changes the upsampling mode to 'bilinear' with align_corners=True for more accurate upsampling.

-  Added a dropout layer (`self.dropout`) with a dropout probability of 0.5.
 -  Changed the mode of the upsampling layers to 'bilinear' with `align_corners=True` for more accurate interpolation during upsampling.